### PR TITLE
Rename elements* to nodes*

### DIFF
--- a/.changeset/lucky-actors-destroy.md
+++ b/.changeset/lucky-actors-destroy.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/preact-perf-metrics': minor
+---
+
+rename elements* to nodes*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This utility allows you to instrument you preact application bundle, and to writ
 
 Using this tool, you can ensure that the performance of your pages don't regress unintentionally. 
 
-Read the [release blog post](https://loveholidays.com) and see the [/example](/example) for more information.
+See the [/example](/example) for practical information.
 
 <i>Made with ❤️ by loveholidays.com</i>
 
@@ -38,7 +38,7 @@ setup();
 ```
 
 > [!NOTE]
-> you might want to call `setup()` only in a testing environment, not in the production build. 
+> you might want to call `setup()` only in a testing environment (and **not** in the production build) because the instrumentation adds some overhead.
 > Similarly to what you would do with `preact/debug` for the devtools.
 
 #### 3- Configure Playwright extension
@@ -72,7 +72,7 @@ test("...", await ({page}) => {
     await page.getByText('Button').click();
 
     // test: use of custom matcher `toPerform`
-    await expect(page).toPerform({ elementsRendered: 1, renderPhases: 1 });
+    await expect(page).toPerform({ nodesRendered: 1, renderPhases: 1 });
 })
 ```
 
@@ -96,9 +96,9 @@ The parameter to assert is an object with one or many of the following keys:
 
 ```js
 interface Counters {
-  elementsRendered?: number;
+  nodesRendered?: number;
   renderPhases?: number;
-  elementsUnmounted?: number;
+  nodesUnmmouted?: number;
 }
 ```
 
@@ -106,12 +106,12 @@ Example:
 ```js
 await reset();
 await page.locator('.counter').click();
-await expect(page).toPerform({ elementsRerendered: 1 });
+await expect(page).toPerform({ nodesRendered: 1 });
 ```
 
 ### `expect().toRerender(...)`
 
-[Playwright Custom matcher](https://playwright.dev/docs/test-assertions#add-custom-matchers-using-expectextend) to assert on the list of elements rerendered during an interaction.
+[Playwright Custom matcher](https://playwright.dev/docs/test-assertions#add-custom-matchers-using-expectextend) to assert on the list of nodes rendered during an interaction.
 
 The parameter to assert is an array of strings, with the names of the preact-nodes involved:
 

--- a/example/perf-test/counter.spec.ts
+++ b/example/perf-test/counter.spec.ts
@@ -4,14 +4,14 @@ import { reset } from '@loveholidays/preact-perf-metrics';
 const RUNNING_URL = 'http://localhost:5173/counters';
 
 test.describe('Counters', () => {
-  test.describe('Elements Rendered', () => {
+  test.describe('Nodes Rendered', () => {
     test('Counter-1 - Memoed button + inline callback', async ({ page }) => {
       await page.goto(RUNNING_URL);
       await reset(page);
       await page.getByText('Counter-1: 0').waitFor();
       await page.getByRole('button', { name: 'Counter-1' }).click();
       await page.getByText('Counter-1: 1').waitFor();
-      await expect(page).toPerform({ elementsRendered: 3 });
+      await expect(page).toPerform({ nodesRendered: 3 });
     });
 
     test('Counter-2 - Memoed button + useCallback callback', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Counters', () => {
       await page.getByText('Counter-2: 0').waitFor();
       await page.getByRole('button', { name: 'Counter-2' }).click();
       await page.getByText('Counter-2: 1').waitFor();
-      await expect(page).toPerform({ elementsRendered: 1 });
+      await expect(page).toPerform({ nodesRendered: 1 });
     });
   });
 
@@ -50,7 +50,7 @@ test.describe('Counters', () => {
       await page.getByRole('button', { name: 'Counter-2' }).click();
       await page.getByRole('button', { name: 'Counter-2' }).click();
       await page.getByText('Counter-2: 2').waitFor();
-      await expect(page).toPerform({ elementsUnmounted: 0 });
+      await expect(page).toPerform({ nodesUnmounted: 0 });
     });
     test('Counter-5 - Conditional mounting/unmounting', async ({ page }) => {
       await page.goto(RUNNING_URL);
@@ -59,19 +59,19 @@ test.describe('Counters', () => {
       await page.getByRole('button', { name: 'Counter-5' }).click();
       await page.getByRole('button', { name: 'Counter-5' }).click();
       await page.getByText('Counter-5: 2').waitFor();
-      await expect(page).toPerform({ elementsUnmounted: 2 });
+      await expect(page).toPerform({ nodesUnmounted: 2 });
     });
   });
 
-  test.describe('Elements Rerendered', () => {
+  test.describe('Nodes Rerendered', () => {
     test('Counter-2 - Memoed Button + useCallback callback', async ({ page }) => {
       await page.goto(RUNNING_URL);
       await reset(page);
       await page.getByText('Counter-2: 0').waitFor();
       await page.getByRole('button', { name: 'Counter-2' }).click();
       await page.getByText('Counter-2: 1').waitFor();
-      await expect(page).toRerenderElements(['Counter2']);
-      await expect(page).toPerform({ elementsRendered: 1, elementsUnmounted: 0, renderPhases: 1 });
+      await expect(page).toRerenderNodes(['Counter2']);
+      await expect(page).toPerform({ nodesRendered: 1, nodesUnmounted: 0, renderPhases: 1 });
     });
     test('Counter-1 - Memoed Button + inline callback', async ({ page }) => {
       await page.goto(RUNNING_URL);
@@ -79,8 +79,8 @@ test.describe('Counters', () => {
       await page.getByText('Counter-1: 0').waitFor();
       await page.getByRole('button', { name: 'Counter-1' }).click();
       await page.getByText('Counter-1: 1').waitFor();
-      await expect(page).toRerenderElements(['Counter1', 'Memo(Button)', 'Button']);
-      await expect(page).toPerform({ elementsRendered: 3, elementsUnmounted: 0, renderPhases: 1 });
+      await expect(page).toRerenderNodes(['Counter1', 'Memo(Button)', 'Button']);
+      await expect(page).toPerform({ nodesRendered: 3, nodesUnmounted: 0, renderPhases: 1 });
     });
   });
 });

--- a/example/perf-test/items-list.spec.ts
+++ b/example/perf-test/items-list.spec.ts
@@ -3,19 +3,19 @@ import { reset } from '@loveholidays/preact-perf-metrics';
 
 const RUNNING_URL = 'http://localhost:5173/items-list';
 
-test.describe('Elements Rendered', () => {
+test.describe('Nodes Rendered', () => {
   test('ListItem as Function', async ({ page }) => {
     await page.goto(RUNNING_URL);
     await page.getByRole('button', { name: 'as-inline-function Next' }).waitFor();
     await reset(page);
     await page.getByRole('button', { name: 'as-inline-function Next' }).click();
-    await expect(page).toPerform({ elementsUnmounted: 18 });
+    await expect(page).toPerform({ nodesUnmounted: 18 });
   });
   test('ListItem as Component', async ({ page }) => {
     await page.goto(RUNNING_URL);
     await page.getByRole('button', { name: 'as-component Next' }).waitFor();
     await reset(page);
     await page.getByRole('button', { name: 'as-component Next' }).click();
-    await expect(page).toPerform({ elementsUnmounted: 0 });
+    await expect(page).toPerform({ nodesUnmounted: 0 });
   });
 });

--- a/src/playwrightUtils.ts
+++ b/src/playwrightUtils.ts
@@ -2,15 +2,15 @@ import type { Page } from '@playwright/test';
 import { diff } from 'jest-diff';
 
 interface Counters {
-  elementsRendered: number;
+  nodesRendered: number;
   renderPhases: number;
-  elementsUnmounted: number;
+  nodesUnmounted: number;
 }
 
 interface PageCounters {
-  elementsRendered: string[],
+  nodesRendered: string[],
   renderPhases: string[],
-  elementsUnmounted: string[],
+  nodesUnmounted: string[],
 }
 
 const reset = async (page: Page) => {
@@ -18,9 +18,9 @@ const reset = async (page: Page) => {
   await page.evaluate(() => {
     const w = window as any;
     w.__PREACT_PERFMETRICS__ = {
-      elementsRendered: [],
+      nodesRendered: [],
       renderPhases: [],
-      elementsUnmounted: [],
+      nodesUnmounted: [],
       lastInteraction: performance.now(),
       waitForInteractionsFinished: () => {
         return new Promise<void>((resolve) => {
@@ -44,15 +44,15 @@ const settle = async (page: Page) => await page.evaluate('window.__PREACT_PERFME
 const equals = (a: any, b: any) => JSON.stringify(a) === JSON.stringify(b);
 
 const extension = {
-  async toRerenderElements(page: Page, expected: string[]) {
+  async toRerenderNodes(page: Page, expected: string[]) {
     if (!page.evaluate) {
-      throw Error("You need to call `toRerenderElements` from a playwright's `page` object");
+      throw Error("You need to call `toRerenderNodes` from a playwright's `page` object");
     }
     await settle(page);
 
     const pageCounters = await getPageCounters(page);
-    const pass =  equals(expected, pageCounters.elementsRendered);
-    const messageStr = diff(expected, pageCounters.elementsRendered);
+    const pass =  equals(expected, pageCounters.nodesRendered);
+    const messageStr = diff(expected, pageCounters.nodesRendered);
 
     return {
       message: () => messageStr,
@@ -88,7 +88,7 @@ declare global {
   export namespace PlaywrightTest {
     export interface Matchers<R, T = unknown> {
       toPerform: (expected: Partial<Counters>) => Promise<void>;
-      toRerenderElements: (rerender: string[]) => Promise<void>;
+      toRerenderNodes: (rerender: string[]) => Promise<void>;
     }
   }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,9 +3,9 @@ import { options, Fragment } from 'preact';
 const reset = () => {
   const w = window as any;
   w.__PREACT_PERFMETRICS__ = {
-    elementsRendered: [],
+    nodesRendered: [],
     renderPhases: [],
-    elementsUnmounted: [],
+    nodesUnmounted: [],
     lastInteraction: performance.now(),
     waitForInteractionsFinished: () => {
       return new Promise<void>((resolve: any) => {
@@ -46,7 +46,7 @@ const setup = () => {
 
   reset();
   o.__r = (vnode: any) => {
-    w.__PREACT_PERFMETRICS__.elementsRendered.push(displayName(vnode));
+    w.__PREACT_PERFMETRICS__.nodesRendered.push(displayName(vnode));
     w.__PREACT_PERFMETRICS__.lastInteraction = performance.now();
     render(vnode);
   };
@@ -57,7 +57,7 @@ const setup = () => {
   };
 
   o.unmount = (vnode: any) => {
-    w.__PREACT_PERFMETRICS__.elementsUnmounted.push(displayName(vnode));
+    w.__PREACT_PERFMETRICS__.nodesUnmounted.push(displayName(vnode));
     w.__PREACT_PERFMETRICS__.lastInteraction = performance.now();
     unmount(vnode);
   };


### PR DESCRIPTION
renames:
* elementsRendered -> nodesRendered
* elementsUnmounted -> nodesUnmounted

The rationale is that the tool works with nodes (`vnode`) which are not 1:1 mapped to "html elements", and might be the source of confusion.