### PR TITLE
feat: Add ToPerformAtMost

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -9,9 +9,10 @@ We have a quick list of common questions to get you started engaging with this p
 
 ## The TLDR version
 
-1. Run `npm run changeset` before pushing your changes. This will launch an interactive CLI dialog where you can describe your changes to all the affected packages, and you can specify which version should be bumped (major / minor / patch).
-2. This will create a YAML file in this folder with the details you described. This file has a random generated name, so multiple YAML files can be stored here. Push this file to your branch.
-3. When we publish our changes from the `main` branch, Changesets aggregates all the YAML files in this repository and figures out what versions need to be bumped. For example, if there were 2 changes for `@loveholidays/phrasebook` where one of them is a breaking change (updating major) and one of them is a bugfix (updating patch), then it will just update the major as a result, and will include both changes in the changelog. It also publishes the new versions, updates the Github changelog and deletes these YAML files.
+1. Install `@changesets/cli` with `npm install -g @changesets/cli`
+2. Run `npx changeset` before pushing your changes. This will launch an interactive CLI dialog where you can describe your changes to all the affected packages, and you can specify which version should be bumped (major / minor / patch).
+3. This will create a YAML file in this folder with the details you described. This file has a random generated name, so multiple YAML files can be stored here. Push this file to your branch.
+4. When we publish our changes from the `main` branch, Changesets aggregates all the YAML files in this repository and figures out what versions need to be bumped. For example, if there were 2 changes for `@loveholidays/phrasebook` where one of them is a breaking change (updating major) and one of them is a bugfix (updating patch), then it will just update the major as a result, and will include both changes in the changelog. It also publishes the new versions, updates the Github changelog and deletes these YAML files.
 
 **Not every change requires a changeset!**
 

--- a/.changeset/empty-schools-nail.md
+++ b/.changeset/empty-schools-nail.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/preact-perf-metrics': minor
+---
+
+Adding ToPerformAtMost Matcher and a minor refactor

--- a/example/perf-test/counter.spec.ts
+++ b/example/perf-test/counter.spec.ts
@@ -84,7 +84,7 @@ test.describe('Counters', () => {
   });
 
   test.describe('toPerformAtMost', () => {
-    test('Counter-3 -To perform at most', async ({page}) => {
+    test('Counter-3 - to perform at most', async ({page}) => {
       await page.goto(RUNNING_URL);
       await reset(page);
       await page.getByText('Counter-1: 0').waitFor();

--- a/example/perf-test/counter.spec.ts
+++ b/example/perf-test/counter.spec.ts
@@ -62,7 +62,6 @@ test.describe('Counters', () => {
       await expect(page).toPerform({ nodesUnmounted: 2 });
     });
   });
-
   test.describe('Nodes Rerendered', () => {
     test('Counter-2 - Memoed Button + useCallback callback', async ({ page }) => {
       await page.goto(RUNNING_URL);
@@ -81,6 +80,31 @@ test.describe('Counters', () => {
       await page.getByText('Counter-1: 1').waitFor();
       await expect(page).toRerenderNodes(['Counter1', 'Memo(Button)', 'Button']);
       await expect(page).toPerform({ nodesRendered: 3, nodesUnmounted: 0, renderPhases: 1 });
+    });
+  });
+
+  test.describe('toPerformAtMost', () => {
+    test('Counter-3 -To perform at most', async ({page}) => {
+      await page.goto(RUNNING_URL);
+      await reset(page);
+      await page.getByText('Counter-1: 0').waitFor();
+      await page.getByRole('button', {name: 'Counter-1'}).click();
+      await page.getByText('Counter-1: 1').waitFor();
+      await expect(page).toPerformAtMost({nodesRendered: 4, renderPhases: 2, nodesUnmounted: 2});
+    });
+  });
+
+  test.describe('toPerformAtMost failure', () => {
+    test('Counter-3 - to fail when breaking limits', async ({ page }) => {
+      await page.goto(RUNNING_URL);
+      await reset(page);
+      await page.getByText('Counter-1: 0').waitFor();
+      await page.getByRole('button', { name: 'Counter-1' }).click();
+      await page.getByText('Counter-1: 1').waitFor();
+
+      await expect(page)
+          .not
+          .toPerformAtMost({ nodesRendered: 2, renderPhases: 0, nodesUnmounted: 0 })
     });
   });
 });

--- a/example/perf-test/items-list.spec.ts
+++ b/example/perf-test/items-list.spec.ts
@@ -18,4 +18,25 @@ test.describe('Nodes Rendered', () => {
     await page.getByRole('button', { name: 'as-component Next' }).click();
     await expect(page).toPerform({ nodesUnmounted: 0 });
   });
+
+  test.describe('toPerformAtMost', () => {
+    test('to pass when within limits', async ({page}) => {
+      await page.goto(RUNNING_URL);
+      await page.getByRole('button', {name: 'as-inline-function Next'}).waitFor();
+      await reset(page);
+      await page.getByRole('button', {name: 'as-inline-function Next'}).click();
+      await expect(page).toPerformAtMost({nodesUnmounted: 20});
+    });
+  });
+  test.describe('toPerformAtMost failure', () => {
+    test('to fail when limits exceeded', async ({ page }) => {
+      await page.goto(RUNNING_URL);
+      await page.getByRole('button', { name: 'as-inline-function Next' }).waitFor();
+      await reset(page);
+      await page.getByRole('button', { name: 'as-inline-function Next' }).click();
+      await expect(page)
+          .not
+          .toPerformAtMost({ nodesUnmounted: 10 });
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { extension, counters, reset} from './playwrightUtils';
+import { counters, extension, reset } from './playwrightUtils';
 import { setup } from './setup';
 
 export { extension, counters, reset, setup };


### PR DESCRIPTION
This PR adds a new match `ToPerformAtMost` which sets a maximum limit on `nodesRendered`, `renderPhases` and `nodesUnmounted` instead of expecting exact values 

Context: We wish to be able to make perf tests more flexible and less fragile going forward